### PR TITLE
Fix P2P ID usage and stabilize E2E tests

### DIFF
--- a/client/p2p.py
+++ b/client/p2p.py
@@ -80,9 +80,14 @@ def get_secret_data(local_port: int) -> dict:
     # Try UPnP first
     external_ip = nat.setup_upnp()
     
-    # If UPnP fails, use STUN
+    # If UPnP fails, try STUN
     if not external_ip:
-        external_ip, external_port = nat.get_stun_info()
+        try:
+            external_ip, external_port = nat.get_stun_info()
+        except Exception as e:
+            print(f"STUN failed: {e}")
+            external_ip = nat._get_local_ip()
+            external_port = local_port
     else:
         external_port = local_port
         

--- a/client/p2p_ops.py
+++ b/client/p2p_ops.py
@@ -4,7 +4,7 @@ from p2p import P2PConnection, fetch_peer_secret, get_secret_data
 async def p2p_receive(reservation_id, local_port, storage_dir, server):
     secret_data = get_secret_data(local_port)
     # Fetch peer secret (blocking for now)
-    peer_secret = await fetch_peer_secret(reservation_id, secret_data["id"], server)
+    peer_secret = await fetch_peer_secret(reservation_id, secret_data["peer_id"], server)
     p2p = P2PConnection(local_port)
     await p2p.connect_to_peer(peer_secret)
     # TODO: implement file-receiving logic here
@@ -17,5 +17,5 @@ async def p2p_connect_and_send(reservation_id, client_id, local_port, file_path,
     if file_path:
         with file_path.open("rb") as f:
             bytes_sent = p2p.send_data(f)
-            await report_usage_func(client_id, secret["id"], bytes_sent, server)
+            await report_usage_func(client_id, secret["peer_id"], bytes_sent, server)
     p2p.close()

--- a/test_end_to_end.py
+++ b/test_end_to_end.py
@@ -17,53 +17,107 @@ def run_cli(args, cwd=None):
     return result.stdout, result.stderr, result.returncode
 
 def test_end_to_end():
-    # Setup temp dirs for Alice and Bob
-    tmpdir = tempfile.mkdtemp()
-    alice_dir = Path(tmpdir) / "alice_storage"
-    bob_dir = Path(tmpdir) / "bob_storage"
-    alice_dir.mkdir()
-    bob_dir.mkdir()
-    print(f"[INFO] Alice storage: {alice_dir}\n[INFO] Bob storage: {bob_dir}")
-    # 1. Register Alice
-    out, err, code = run_cli([
-        "register", "--client-id", "Alice", "--endpoint", "127.0.0.1:9002", "--space", "50", "--storage-dir", str(alice_dir)
-    ])
-    print("[REGISTER ALICE]", out)
-    assert code == 0, f"Alice registration failed: {err}"
-    # 2. Register Bob
-    out, err, code = run_cli([
-        "register", "--client-id", "Bob", "--endpoint", "127.0.0.1:9003", "--space", "100", "--storage-dir", str(bob_dir)
-    ])
-    print("[REGISTER BOB]", out)
-    assert code == 0, f"Bob registration failed: {err}"
-    # 3. Alice discovers offers
-    out, err, code = run_cli(["offers", "--min-space", "50"])
-    print("[OFFERS]", out)
-    assert "Bob" in out, "Bob not found in offers"
-    # 4. Alice reserves space on Bob
-    out, err, code = run_cli(["reserve", "--from-id", "Alice", "--to-id", "Bob", "--amount", "20"])
-    print("[RESERVE]", out)
-    assert "Reserved" in out, "Reservation failed"
-    rid = None
-    for line in out.splitlines():
-        if "Reserved:" in line:
-            rid = line.split(":")[-1].strip()
-    assert rid, "No reservation_id found"
-    # 5. Bob lists incoming requests
-    out, err, code = run_cli(["requests", "--client-id", "Bob"])
-    print("[REQUESTS]", out)
-    assert rid in out, "Reservation not listed for Bob"
-    # 6. Bob approves reservation (simulate auto-confirm)
-    out, err, code = run_cli(["approve", rid, "--local-port", "9003", "--storage-dir", str(bob_dir)])
-    print("[APPROVE]", out)
-    assert "Secret announced" in out, "Approval failed"
-    # 7. Alice fetches Bob's secret and (mock) connects
-    out, err, code = run_cli(["p2p-connect", rid, "--client-id", "Alice", "--local-port", "9002", "--server", "http://localhost:8000"])
-    print("[P2P-CONNECT]", out)
-    # Accept both success and error (since P2P is not implemented)
-    assert code == 0 or "P2P error" in out or "P2P error" in err
-    # Cleanup
-    shutil.rmtree(tmpdir)
+    # Start API server
+    if os.path.exists("clients.json"):
+        os.remove("clients.json")
+    server_proc = subprocess.Popen(
+        ["python3", "-m", "uvicorn", "server:app", "--port", "8000"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    time.sleep(1)
+    try:
+        # Setup temp dirs for Alice and Bob
+        tmpdir = tempfile.mkdtemp()
+        alice_dir = Path(tmpdir) / "alice_storage"
+        bob_dir = Path(tmpdir) / "bob_storage"
+        alice_dir.mkdir()
+        bob_dir.mkdir()
+        print(f"[INFO] Alice storage: {alice_dir}\n[INFO] Bob storage: {bob_dir}")
+
+        # 1. Register Alice
+        out, err, code = run_cli([
+            "register",
+            "--client-id",
+            "Alice",
+            "--endpoint",
+            "127.0.0.1:9002",
+            "--space",
+            "50",
+            "--storage-dir",
+            str(alice_dir),
+        ])
+        print("[REGISTER ALICE]", out)
+        assert code == 0, f"Alice registration failed: {err}"
+        # 2. Register Bob
+        out, err, code = run_cli([
+            "register",
+            "--client-id",
+            "Bob",
+            "--endpoint",
+            "127.0.0.1:9003",
+            "--space",
+            "100",
+            "--storage-dir",
+            str(bob_dir),
+        ])
+        print("[REGISTER BOB]", out)
+        assert code == 0, f"Bob registration failed: {err}"
+        # 3. Alice discovers offers
+        out, err, code = run_cli(["offers", "--min-space", "50"])
+        print("[OFFERS]", out)
+        assert "Bob" in out, "Bob not found in offers"
+        # 4. Alice reserves space on Bob
+        out, err, code = run_cli([
+            "reserve",
+            "--from-id",
+            "Alice",
+            "--to-id",
+            "Bob",
+            "--amount",
+            "20",
+        ])
+        print("[RESERVE]", out)
+        assert "Reserved" in out, "Reservation failed"
+        rid = None
+        for line in out.splitlines():
+            if "Reserved:" in line:
+                rid = line.split(":")[-1].strip()
+        assert rid, "No reservation_id found"
+        # 5. Bob lists incoming requests
+        out, err, code = run_cli(["requests", "--client-id", "Bob"])
+        print("[REQUESTS]", out)
+        assert rid in out, "Reservation not listed for Bob"
+        # 6. Bob approves reservation (simulate auto-confirm)
+        out, err, code = run_cli([
+            "approve",
+            rid,
+            "--local-port",
+            "9003",
+            "--storage-dir",
+            str(bob_dir),
+        ])
+        print("[APPROVE]", out)
+        assert "Secret announced" in out, "Approval failed"
+        # 7. Alice fetches Bob's secret and (mock) connects
+        out, err, code = run_cli([
+            "p2p-connect",
+            rid,
+            "--client-id",
+            "Alice",
+            "--local-port",
+            "9002",
+            "--server",
+            "http://localhost:8000",
+        ])
+        print("[P2P-CONNECT]", out)
+        # Accept both success and error (since P2P is not implemented)
+        assert code == 0 or "P2P error" in out or "P2P error" in err
+        # Cleanup
+        shutil.rmtree(tmpdir)
+    finally:
+        server_proc.terminate()
+        server_proc.wait()
 
 if __name__ == "__main__":
     test_end_to_end()


### PR DESCRIPTION
## Summary
- fix wrong key name in p2p operations
- handle STUN failure gracefully
- start API server during end-to-end tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400c455d808330b3ee294d15d0747d