### PR TITLE
Fix peer ID usage in P2P ops

### DIFF
--- a/client/p2p.py
+++ b/client/p2p.py
@@ -39,8 +39,14 @@ class NATTraversal:
         return socket.gethostbyname(socket.gethostname())
 
     def get_stun_info(self) -> tuple:
-        nat_type, external_ip, external_port = stun.get_ip_info()
-        return external_ip, external_port
+        try:
+            nat_type, external_ip, external_port = stun.get_ip_info()
+            return external_ip, external_port
+        except Exception as e:
+            print(f"STUN failed: {e}")
+            # Fallback to local interface if STUN is unavailable
+            local_ip = self._get_local_ip()
+            return local_ip, self.local_port
 
 SecretData = {
     "local_endpoint": "ip:port",      # the peer's listening address

--- a/client/p2p_ops.py
+++ b/client/p2p_ops.py
@@ -4,7 +4,7 @@ from p2p import P2PConnection, fetch_peer_secret, get_secret_data
 async def p2p_receive(reservation_id, local_port, storage_dir, server):
     secret_data = get_secret_data(local_port)
     # Fetch peer secret (blocking for now)
-    peer_secret = await fetch_peer_secret(reservation_id, secret_data["id"], server)
+    peer_secret = await fetch_peer_secret(reservation_id, secret_data["peer_id"], server)
     p2p = P2PConnection(local_port)
     await p2p.connect_to_peer(peer_secret)
     # TODO: implement file-receiving logic here
@@ -17,5 +17,5 @@ async def p2p_connect_and_send(reservation_id, client_id, local_port, file_path,
     if file_path:
         with file_path.open("rb") as f:
             bytes_sent = p2p.send_data(f)
-            await report_usage_func(client_id, secret["id"], bytes_sent, server)
+            await report_usage_func(client_id, secret["peer_id"], bytes_sent, server)
     p2p.close()


### PR DESCRIPTION
## Summary
- fix secret key names in p2p_ops
- handle STUN failures gracefully during NAT traversal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400d52f7bc8330b97105b5ecabf8b5